### PR TITLE
fix: 恢复设置页顶部拖拽并避开窗口控制区

### DIFF
--- a/desktop/src/settings.html
+++ b/desktop/src/settings.html
@@ -45,12 +45,13 @@
             background: transparent;
             border-bottom: none;
         }
-        /* Windows/Linux：无红绿灯，不需要大 padding-top；
-           取消 header drag，改由 titlebar-minimal 承担拖拽 */
+        /* Windows/Linux：保留顶部可见 header 作为拖拽区；
+           titlebar-minimal 只承载 window controls */
         html[data-platform="win32"] .settings-header,
         html[data-platform="linux"] .settings-header {
-            -webkit-app-region: no-drag;
+            -webkit-app-region: drag;
             padding-top: 10px;
+            margin-right: 150px;
         }
         html[data-platform="win32"] .titlebar-minimal,
         html[data-platform="linux"] .titlebar-minimal {


### PR DESCRIPTION
## 改了什么

现在我把设置页顶部栏恢复成可拖拽区，并给右侧窗口控制按钮预留了空间，当前这次修改只影响 Windows/Linux。

## 为什么改

无法通过鼠标拖动移动窗口位置

## 测试

- [ ] `npm test` 通过
- [ ] `npm run typecheck` 通过
- [ ] 手动测试过相关功能
