### PR TITLE
Add support for docx files in bridge attachments

### DIFF
--- a/lib/bridge/bridge-manager.js
+++ b/lib/bridge/bridge-manager.js
@@ -686,10 +686,37 @@ export class BridgeManager {
       "less", "svg", "env", "gitignore", "dockerignore", "makefile",
       "dockerfile", "rst", "tex", "bib",
     ]);
+    const DOCX_EXTS = new Set(["docx"]);
     const MAX_TEXT_FILE_SIZE = 1024 * 1024; // 1MB
 
     const filename = (att.filename || "").toLowerCase();
     const ext = filename.split(".").pop() || "";
+    
+    // 处理 docx 文件
+    if (DOCX_EXTS.has(ext)) {
+      try {
+        const buffer = await this._downloadAttachment(adapter, att);
+        if (!buffer) return null;
+        if (buffer.length > MAX_TEXT_FILE_SIZE) return null;
+        
+        // 保存临时文件
+        const tempPath = `/tmp/${Date.now()}.docx`;
+        require('fs').writeFileSync(tempPath, buffer);
+        
+        // 使用 mammoth 提取文本
+        const mammoth = (await import("mammoth")).default;
+        const result = await mammoth.extractRawText({ path: tempPath });
+        
+        // 清理临时文件
+        require('fs').unlinkSync(tempPath);
+        
+        return result.value;
+      } catch (err) {
+        debugLog()?.warn("bridge", `docx 解析失败: ${err.message}`);
+        return null;
+      }
+    }
+    
     if (!TEXT_EXTENSIONS.has(ext)) return null;
 
     // 已知大小超限则跳过


### PR DESCRIPTION
This PR adds support for processing docx files from Feishu and other bridge platforms.

Changes:
- Modified lib/bridge/bridge-manager.js to detect and process docx files
- Integrated mammoth library to extract text from docx files
- Added proper error handling and temporary file management

Now Hanako can read docx files from Feishu just like local docx files.